### PR TITLE
initialising stripe config vars after setting them in heroku

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,2 +1,6 @@
-Stripe.api_key = Rails.application.secrets.secret_key
-STRIPE_PUBLIC_KEY = Rails.application.secrets.stripe_public_key
+Rails.configuration.stripe = {
+  :publishable_key => ENV['PUBLISHABLE_KEY'],
+  :secret_key      => ENV['SECRET_KEY']
+}
+
+Stripe.api_key = Rails.configuration.stripe[:secret_key]


### PR DESCRIPTION
You weren't initialising stripe properly and you never set up your PUBLISHABLE_KEY and SECRET_KEY config vars on heroku.

https://stripe.com/docs/checkout/guides/rails
https://devcenter.heroku.com/articles/config-vars
